### PR TITLE
Vori stan alignment with PKPDsim

### DIFF
--- a/inst/models/pk_voriconazole_friberg.stan
+++ b/inst/models/pk_voriconazole_friberg.stan
@@ -1,3 +1,6 @@
+// The bioavailability & absorption lag model described by the Friberg et al 
+// (AAC, 2012) publication has not been implemented. Please use this only for 
+// infusion medication administration simulations.
 functions{
   vector ode(real t, vector A, real[] theta, real[] x_r, int[] x_i){
     
@@ -7,19 +10,20 @@ functions{
     // define_ode_parameters  
     real CL = theta[1];
     real Q = theta[2];
-    real V1 = theta[3];
+    real V = theta[3];
     real V2 = theta[4];
     real KA = theta[5];
     real KM = theta[6];
     real VMAX1 = theta[7];
+    real T50 = theta[8];
     
-    real k10 = CL / V1;
-    real k12 = Q / V1;
+    real k10 = CL / V;
+    real k12 = Q / V;
     real k21 = Q / V2;
     real VMAXINH = exp(1.5) / (1 + exp(1.5));
-    real Vmax = VMAX1 * (1 - VMAXINH * (t-1) / ((t-1) + (2.41 - 1))); // T50 = 2.41
+    real Vmax = VMAX1 * (1 - VMAXINH * (t-1) / ((t-1) + (T50 - 1)));
     dAdt[1] = -KA*A[1];
-    dAdt[2] =  KA*A[1] - (k10 + k12)*A[2] + k21*A[3] - (Vmax * A[2]/V1)/(KM + A[2]/V1);
+    dAdt[2] =  KA*A[1] - (k10 + k12)*A[2] + k21*A[3] - (Vmax * A[2]/V)/(KM + A[2]/V);
     dAdt[3] = k12*A[2] - k21*A[3];
 
     return dAdt;
@@ -34,20 +38,28 @@ data {
   // population parameters
   real<lower = 0> theta_CL;
   real<lower = 0> theta_Q;
-  real<lower = 0> theta_V1;
+  real<lower = 0> theta_V;
   real<lower = 0> theta_V2;
   real<lower = 0> theta_KA;
   real<lower = 0> theta_KM;
   real<lower = 0> theta_VMAX1;
+  real<lower = 0> theta_T50;
+  real<lower = 0> theta_TLAG; // not used, for compatibility
+  real<lower = 0> theta_F1; // not used, for compatibility
+  real<lower = 0> theta_BCF; // not used, for compatibility
   
   // inter-individual variability (SD scale)
   real<lower = 0> omega_CL;
   real<lower = 0> omega_Q;
-  real<lower = 0> omega_V1;
+  real<lower = 0> omega_V;
   real<lower = 0> omega_V2;
   real<lower = 0> omega_KA;
   real<lower = 0> omega_KM;
   real<lower = 0> omega_VMAX1;
+  real<lower = 0> omega_T50; // not used, for compatibility
+  real<lower = 0> omega_TLAG; // not used, for compatibility
+  real<lower = 0> omega_F1; // not used, for compatibility
+  real<lower = 0> omega_BCF; // not used, for compatibility
 
   // error model
   int<lower = 0, upper = 1> ltbs_pk; // should log-transform-both-sides be used for observations? (boolean)
@@ -72,14 +84,14 @@ data {
 
 transformed data {
   row_vector[n_obs_pk] log_dv_pk = log(dv_pk);
-  int n_theta = 7;   // number of parameters
+  int n_theta = 8;   // number of parameters
   int n_cmt = 3;   // number of compartments
 }
 
 parameters {
   real<lower = 0> CL;
   real<lower = 0> Q;
-  real<lower = 0> V1;
+  real<lower = 0> V;
   real<lower = 0> V2;
   real<lower = 0> KA;
   real<lower = 0> KM;
@@ -91,19 +103,24 @@ transformed parameters {
   row_vector<lower = 0>[n_t] ipred_pk;
   row_vector<lower = 0>[n_obs_pk] ipred_obs_pk;
   matrix<lower = 0>[3, n_t] A; 
+  real<lower = 0> T50 = theta_T50;
+  real<lower = 0> TLAG = theta_TLAG;
+  real<lower = 0> F1 = theta_F1;
+  real<lower = 0> BCF = theta_BCF;
 
   theta[1] = CL * pow(mean(WT)/70, 0.75);
   theta[2] = Q * 1.637 * pow(mean(WT)/70, 0.75);
-  theta[3] = V1 * mean(WT)/70;
+  theta[3] = V * mean(WT)/70;
   theta[4] = V2 * mean(WT)/70;
   theta[5] = KA;
   theta[6] = KM;
   theta[7] = VMAX1 * pow(mean(WT)/70, 0.75);
+  theta[8] = T50;
   // theta[8] = F1;
   
   A = pmx_solve_rk45(ode, 3, time, amt, rate, ii, evid, cmt, addl, ss, theta, 1e-5, 1e-8, 1e5);
 
-  ipred_pk = A[2, ] ./ V1;
+  ipred_pk = A[2, ] ./ (V * mean(WT)/70);
 
   for(i in 1:n_obs_pk){
     ipred_obs_pk[i] = ipred_pk[i_obs_pk[i]];  // predictions for observed data records
@@ -114,7 +131,7 @@ model{
   // informative prior
   CL ~ lognormal(log(theta_CL), omega_CL);
   Q  ~ lognormal(log(theta_Q), omega_Q);
-  V1 ~ lognormal(log(theta_V1), omega_V1);
+  V ~ lognormal(log(theta_V), omega_V);
   V2 ~ lognormal(log(theta_V2), omega_V2);
   KA ~ lognormal(log(theta_KA), omega_KA);
   KM ~ lognormal(log(theta_KM), omega_KM);
@@ -135,7 +152,7 @@ generated quantities{
   // sample prior
   real prior_CL = lognormal_rng(log(theta_CL), omega_CL); //"parameters", "iiv" values
   real prior_Q  = lognormal_rng(log(theta_Q), omega_Q);
-  real prior_V1 = lognormal_rng(log(theta_V1), omega_V1);
+  real prior_V = lognormal_rng(log(theta_V), omega_V);
   real prior_V2 = lognormal_rng(log(theta_V2), omega_V2);
   real prior_KA = lognormal_rng(log(theta_KA), omega_KA);
   real prior_KM = lognormal_rng(log(theta_KM), omega_KM);


### PR DESCRIPTION
This passes model validation, provided we are okay with 1e-4 as a relative delta threshold.

The only substantive change I made to the model file is the scaling, which was incorrectly set to `V1` and not to `V1 * WT/70`. The other lines of code change are simply so the parameters match. I have no yet implemented age/CYP-based covariates.

verify for yourself:

```r
library(PKPDposterior)
library(PKPDsim)
library(pkvoriconazolefriberg)

stan_mod <- load_model("pk_voriconazole_friberg")
pkpdsim_mod <- pkvoriconazolefriberg::model()

regimen_iv <- PKPDsim::new_regimen(
  amt = 500, 
  n = 7, 
  times = c(0, 12, 24, 36, 48, 60, 72), 
  type = 'infusion',
  t_inf = 2
)
tdm_data <- data.frame(
  t = c(59, 70.5), 
  dv = c(1.6, 1.5),
  cmt = c(2, 2)
)
covariates <- list(
  "WT" = new_covariate(50),
  "AGE" = new_covariate(20),
  "CYP2C19unknown" = new_covariate(0),
  "CYP2C19a1a2" = new_covariate(0),
  "CYP2C19a2a2" = new_covariate(0),
  "CYP2C19a2a3" = new_covariate(0),
  "CYP2C19a1a3" = new_covariate(0),
  "CYP2C19a3a3" = new_covariate(0)
)

no_iiv <- list(
  T50 = 0,
  TLAG = 0,
  BCF = 0,
  F1 = 0
)
parameters <- pkvoriconazolefriberg::parameters()
iiv <- c(pkvoriconazolefriberg::iiv(), no_iiv)

dat <- new_stan_data(
  regimen_iv,
  covariates,
  tdm_data,
  parameters,
  iiv = iiv,
  ruv = pkvoriconazolefriberg::ruv(),
  dose_cmt = 2
)

validate_stan_model(
  stan_mod,
  pkpdsim_mod,
  dat,
  verbose = TRUE,
  max_rel_delta = 1e-4
)
```