### PR TITLE
RXR-1119: Set up CI for PKPDposterior

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,3 +6,4 @@ examples
 ^docs$
 ^pkgdown$
 ^\.github$
+Dockerfile

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,4 @@ examples
 ^pkgdown$
 ^\.github$
 Dockerfile
+Jenkinsfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM 579831337053.dkr.ecr.us-west-2.amazonaws.com/irx-r-base:latest
+
+ENV _R_CHECK_TESTS_NLINES_=0
+
+WORKDIR /src
+RUN apt-get -y update
+RUN apt-get -y install git curl
+RUN git clone https://github.com/metrumresearchgroup/Torsten.git
+WORKDIR /src/Torsten/cmdstan
+RUN make build
+
+COPY ./ /src/PKPDposterior
+WORKDIR /src/PKPDposterior
+RUN Rscript -e "devtools::install()"
+RUN Rscript -e "install.packages(c('mockery'), repos = '${RSPM_SNAPSHOT}')"
+ENV CMDSTAN="/src/Torsten/cmdstan"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
     label 'docker-runner'
   }
   stages{
-    stage('Run docker container') {
+    stage('Build docker image') {
       environment {
         AWS_ACCESS_KEY_ID = credentials('AWS_ACCESS_KEY_ID')
         AWS_SECRET_ACCESS_KEY = credentials('AWS_SECRET_ACCESS_KEY')
@@ -19,9 +19,9 @@ pipeline {
       }
 
     }
-    stage('Build & test PKPDsim') {
+    stage('Test PKPDposterior') {
       steps {
-        echo 'Installing and checking PKPDsim'
+        echo 'Installing and checking PKPDposterior'
         /*
         The command to Sys.setlocale('LC_ALL','C') is required due to a bug in processx, which has
         already been fixed in the dev version as of May 26th 2021, but is not yet in the CRAN version.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,44 @@
+#!groovy
+
+pipeline {
+  agent {
+    label 'docker-runner'
+  }
+  stages{
+    stage('Run docker container') {
+      environment {
+        AWS_ACCESS_KEY_ID = credentials('AWS_ACCESS_KEY_ID')
+        AWS_SECRET_ACCESS_KEY = credentials('AWS_SECRET_ACCESS_KEY')
+      }
+      steps {
+        echo "Building Docker image"
+        sh """
+        \$(aws ecr get-login --no-include-email --region us-west-2 &> /dev/null)
+        docker build -t pkpdposterior .
+        """
+      }
+
+    }
+    stage('Build & test PKPDsim') {
+      steps {
+        echo 'Installing and checking PKPDsim'
+        /*
+        The command to Sys.setlocale('LC_ALL','C') is required due to a bug in processx, which has
+        already been fixed in the dev version as of May 26th 2021, but is not yet in the CRAN version.
+        This line can be removed when processx (called by rcmdcheck) is updated.
+        */
+        sh """
+        docker run -d -t --name ${BUILD_TAG} pkpdposterior:latest
+        docker exec -i ${BUILD_TAG} Rscript -e "devtools::check(vignettes = FALSE)"
+        """
+      }
+    }
+  }
+  post {
+    always {
+      sh """
+      docker rm -f ${BUILD_TAG} &>/dev/null && echo 'Removed container'
+      """
+    }
+  }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,11 +22,6 @@ pipeline {
     stage('Test PKPDposterior') {
       steps {
         echo 'Installing and checking PKPDposterior'
-        /*
-        The command to Sys.setlocale('LC_ALL','C') is required due to a bug in processx, which has
-        already been fixed in the dev version as of May 26th 2021, but is not yet in the CRAN version.
-        This line can be removed when processx (called by rcmdcheck) is updated.
-        */
         sh """
         docker run -d -t --name ${BUILD_TAG} pkpdposterior:latest
         docker exec -i ${BUILD_TAG} Rscript -e "devtools::check(vignettes = FALSE)"

--- a/R/new_stan_model.R
+++ b/R/new_stan_model.R
@@ -22,8 +22,9 @@
 #' each observation type. Sometimes this is needed when more flexibility is 
 #' needed than the `scale` parameter provides.
 #' @param verbose verbosity
+#' @inheritParams new_stan_data
 #' 
-#' @returns filename
+#' @return filename
 #' 
 #' @examples
 #' 

--- a/R/validate_stan_model.R
+++ b/R/validate_stan_model.R
@@ -21,8 +21,7 @@ validate_stan_model <- function(
   n = 50,
   max_abs_delta = 1e-3,
   max_rel_delta = 1e-5,
-  verbose = FALSE,
-  ...
+  verbose = FALSE
 ) {
   
   if (verbose) message("Sampling from posterior...")

--- a/man/new_stan_model.Rd
+++ b/man/new_stan_model.Rd
@@ -11,8 +11,8 @@ new_stan_model(
   variable_definitions = NULL,
   ode = NULL,
   covariate_definitions = NULL,
-  solver = c("pmx_solve_onecpt", "pmx_solve_twocpt", "pmx_solve_rk45",
-    "pmx_solve_adams", "pmx_solve_bdf"),
+  solver = c("pmx_solve_onecpt", "pmx_solve_twocpt", "pmx_solve_rk45", "pmx_solve_adams",
+    "pmx_solve_bdf"),
   template = "template.stan",
   obs_types = NULL,
   obs_cmt = NULL,
@@ -26,6 +26,8 @@ new_stan_model(
 
 \item{parameter_definitions}{list of parameter definitions. See example
 below.}
+
+\item{fixed}{optional, vector of parameters to fix and not sample.}
 
 \item{variable_definitions}{for models using the analytical solvers, extra
 variable definitions evaluated at each step through the event table.

--- a/man/parse_model_definitions.Rd
+++ b/man/parse_model_definitions.Rd
@@ -25,6 +25,8 @@ parse_model_definitions(
 \item{parameter_definitions}{list of parameter definitions. See example
 below.}
 
+\item{fixed}{optional, vector of parameters to fix and not sample.}
+
 \item{variable_definitions}{for models using the analytical solvers, extra
 variable definitions evaluated at each step through the event table.
 See busulfan example in vignettes for example.}

--- a/man/validate_stan_model.Rd
+++ b/man/validate_stan_model.Rd
@@ -13,8 +13,7 @@ validate_stan_model(
   n = 50,
   max_abs_delta = 0.001,
   max_rel_delta = 1e-05,
-  verbose = FALSE,
-  ...
+  verbose = FALSE
 )
 }
 \arguments{


### PR DESCRIPTION
Adds a dockerfile and Jenkinsfile to run `devtools::check()` for PKPDposterior. I opted to skip building the vignettes so we don't need to worry about installing pandoc in docker, on the theory that pkgdown already builds the vignettes so we will catch any vignette errors through that pipeline. Also fixed a couple of documentation issues.