### PR TITLE
Fix combined error / ruv implementation (issue #33)

### DIFF
--- a/R/parse_model_definitions.R
+++ b/R/parse_model_definitions.R
@@ -200,7 +200,7 @@ parse_model_definitions <- function(
     "if(ltbs_", obs_types, ") {", cr, "  ",
     "  log_dv_", obs_types, " ~ normal(log(ipred_obs_", obs_types, "), ruv_add_", obs_types, "); ", cr, "  ",
     "} else {", cr, "  ",
-    "  dv_", obs_types, " ~ normal(ipred_obs_", obs_types, ", (sqrt(pow(ruv_prop_", obs_types, " * ipred_obs_", obs_types, ", 2) + pow(ruv_add_", obs_types,", 2)));", cr, "  ",
+    "  dv_", obs_types, " ~ normal(ipred_obs_", obs_types, ", (sqrt(pow(ruv_prop_", obs_types, " * ipred_obs_", obs_types, ", 2) + pow(ruv_add_", obs_types,", 2))));", cr, "  ",
     "}"
   )
   
@@ -214,7 +214,7 @@ parse_model_definitions <- function(
     paste0("real ipred_ruv_", obs_types, "[n_obs_", obs_types, "];"),
     paste0(
        "for(i in 1:n_obs_", obs_types, "){", cr, "  ",
-       "  ipred_ruv_", obs_types, "[i] = normal_rng(ipred_obs_", obs_types, "[i], (sqrt(pow(ruv_prop_", obs_types, " * ipred_obs_", obs_types, "[i], 2) + pow(ruv_add_", obs_types, ", 2)));", cr, "  ",
+       "  ipred_ruv_", obs_types, "[i] = normal_rng(ipred_obs_", obs_types, "[i], (sqrt(pow(ruv_prop_", obs_types, " * ipred_obs_", obs_types, "[i], 2) + pow(ruv_add_", obs_types, ", 2))));", cr, "  ",
        "}"
     ) 
   )

--- a/R/parse_model_definitions.R
+++ b/R/parse_model_definitions.R
@@ -200,7 +200,7 @@ parse_model_definitions <- function(
     "if(ltbs_", obs_types, ") {", cr, "  ",
     "  log_dv_", obs_types, " ~ normal(log(ipred_obs_", obs_types, "), ruv_add_", obs_types, "); ", cr, "  ",
     "} else {", cr, "  ",
-    "  dv_", obs_types, " ~ normal(ipred_obs_", obs_types, ", (ruv_prop_", obs_types, " * ipred_obs_", obs_types, " + ruv_add_", obs_types,"));", cr, "  ",
+    "  dv_", obs_types, " ~ normal(ipred_obs_", obs_types, ", (sqrt(pow(ruv_prop_", obs_types, " * ipred_obs_", obs_types, ", 2) + pow(ruv_add_", obs_types,", 2)));", cr, "  ",
     "}"
   )
   
@@ -214,7 +214,7 @@ parse_model_definitions <- function(
     paste0("real ipred_ruv_", obs_types, "[n_obs_", obs_types, "];"),
     paste0(
        "for(i in 1:n_obs_", obs_types, "){", cr, "  ",
-       "  ipred_ruv_", obs_types, "[i] = normal_rng(ipred_obs_", obs_types, "[i], (ruv_prop_", obs_types, " * ipred_obs_", obs_types, "[i] + ruv_add_", obs_types, "));", cr, "  ",
+       "  ipred_ruv_", obs_types, "[i] = normal_rng(ipred_obs_", obs_types, "[i], (sqrt(pow(ruv_prop_", obs_types, " * ipred_obs_", obs_types, "[i], 2) + pow(ruv_add_", obs_types, ", 2)));", cr, "  ",
        "}"
     ) 
   )


### PR DESCRIPTION
In case you agree with the issue described in #33, I guess it could be simply fixed within `parse_model_definitions()`. In the likelihood section it leads to this change in the `model.stan` file (if generated with `write_stan_model()`):

*original*

```
dv_pk ~ normal(ipred_obs_pk, (ruv_prop_pk * ipred_obs_pk + ruv_add_pk));
```

*new*

```
dv_pk ~ normal(ipred_obs_pk, (sqrt(pow(ruv_prop_pk * ipred_obs_pk, 2) + pow(ruv_add_pk, 2))));
```

and similarily in the simulate_posterior section:

*original*

```
for(i in 1:n_obs_pk){
    ipred_ruv_pk[i] = normal_rng(ipred_obs_pk[i], (ruv_prop_pk * ipred_obs_pk[i] + ruv_add_pk));
  }
```

*new*

```
for(i in 1:n_obs_pk){
  ipred_ruv_pk[i] = normal_rng(ipred_obs_pk[i], (sqrt(pow(ruv_prop_pk * ipred_obs_pk[i], 2) + pow(ruv_add_pk, 2))));
}
```